### PR TITLE
Use peer dependencies as dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
     "grunt-karma-coveralls": "2.5.3",
     "grunt-mocha-test": "0.12.7",
     "grunt-webpack": "1.0.11",
+    "js-data": ">=2.0.0",
     "jit-grunt": "0.9.1",
     "jshint": "2.8.0",
     "jshint-loader": "0.8.3",
+    "rethinkdbdash": ">=1.15.0",
     "sinon": "1.15.4",
     "time-grunt": "1.2.1",
     "webpack-dev-server": "1.10.1"


### PR DESCRIPTION
Define the peer dependencies in devDependencies to fix CI as it is missing `rethinkdbdash`.

This is the simplest fix I can think of without introducing some sort of complex post-install npm script.