### PR TITLE
Adds support for like/notLike and contains/notContains operators

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,6 +90,16 @@ class DSRethinkDBAdapter {
               subQuery = subQuery ? subQuery.and(row(field).default([]).setIntersection(r.expr(v).default([])).count().eq(0)) : row(field).default([]).setIntersection(r.expr(v).default([])).count().eq(0)
             } else if (op === 'isectNotEmpty') {
               subQuery = subQuery ? subQuery.and(row(field).default([]).setIntersection(r.expr(v).default([])).count().ne(0)) : row(field).default([]).setIntersection(r.expr(v).default([])).count().ne(0)
+            } else if (op === 'like') {
+              v = '(i?)' + v // Case-insensitive
+              subQuery = subQuery ? subQuery.and(row(field).default(null).match(v)) : row(field).default(null).match(v)
+            } else if (op === 'notLike') {
+              v = '(i?)' + v // Case-insensitive
+              subQuery = subQuery ? subQuery.and(row(field).default(null).match(v).not()) : row(field).default(null).match(v).not()
+            } else if (op === 'contains') {
+              subQuery = subQuery ? subQuery.and(row(field).default([]).contains(r.expr(v).default(null))) : row(field).default([]).contains(r.expr(v).default(null))
+            } else if (op === 'notContains') {
+              subQuery = subQuery ? subQuery.and(row(field).default([]).contains(r.expr(v).default(null)).not()) : row(field).default([]).contains(r.expr(v).default(null)).not()
             } else if (op === 'in') {
               subQuery = subQuery ? subQuery.and(r.expr(v).default(r.expr([])).contains(row(field).default(null))) : r.expr(v).default(r.expr([])).contains(row(field).default(null))
             } else if (op === 'notIn') {
@@ -110,6 +120,16 @@ class DSRethinkDBAdapter {
               subQuery = subQuery ? subQuery.or(row(field).default([]).setIntersection(r.expr(v).default([])).count().eq(0)) : row(field).default([]).setIntersection(r.expr(v).default([])).count().eq(0)
             } else if (op === '|isectNotEmpty') {
               subQuery = subQuery ? subQuery.or(row(field).default([]).setIntersection(r.expr(v).default([])).count().ne(0)) : row(field).default([]).setIntersection(r.expr(v).default([])).count().ne(0)
+            } else if (op === '|like') {
+              v = '(i?)' + v // Case-insensitive
+              subQuery = subQuery ? subQuery.or(row(field).default(null).match(v)) : row(field).default(null).match(v)
+            } else if (op === '|notLike') {
+              v = '(i?)' + v // Case-insensitive
+              subQuery = subQuery ? subQuery.or(row(field).default(null).match(v).not()) : row(field).default(null).match(v).not()
+            } else if (op === '|contains') {
+              subQuery = subQuery ? subQuery.or(row(field).default([]).contains(r.expr(v).default(null))) : row(field).default([]).contains(r.expr(v).default(null))
+            } else if (op === '|notContains') {
+              subQuery = subQuery ? subQuery.or(row(field).default([]).contains(r.expr(v).default(null)).not()) : row(field).default([]).contains(r.expr(v).default(null)).not()
             } else if (op === '|in') {
               subQuery = subQuery ? subQuery.or(r.expr(v).default(r.expr([])).contains(row(field).default(null))) : r.expr(v).default(r.expr([])).contains(row(field).default(null))
             } else if (op === '|notIn') {

--- a/test/findAll.spec.js
+++ b/test/findAll.spec.js
@@ -49,4 +49,119 @@ describe('DSRethinkDBAdapter#findAll', function () {
       assert.isFalse(!!destroyedUser);
     });
   });
+  it('should filter users using the "notContains" operator', function () {
+    var id;
+
+    return adapter.findAll(User, {
+      where: {
+        roles: {
+          'notContains': 'user'
+        }
+      }
+    }).then(function (users) {
+      assert.equal(users.length, 0);
+      return adapter.create(User, { name: 'John', roles: [ 'admin' ] });
+    }).then(function (user) {
+      id = user.id;
+      return adapter.findAll(User, {
+        where: {
+          roles: {
+            'notContains': 'user'
+          }
+        }
+      });
+    }).then(function (users) {
+      assert.equal(users.length, 1);
+      assert.deepEqual(users[0], { id: id, name: 'John', roles: [ 'admin' ] });
+      return adapter.destroy(User, id);
+    }).then(function (destroyedUser) {
+      assert.isFalse(!!destroyedUser);
+    });
+  });  it('should filter users using the "contains" operator', function () {
+    var id;
+
+    return adapter.findAll(User, {
+      where: {
+        roles: {
+          'contains': 'admin'
+        }
+      }
+    }).then(function (users) {
+      assert.equal(users.length, 0);
+      return adapter.create(User, { name: 'John', roles: [ 'admin' ] });
+    }).then(function (user) {
+      id = user.id;
+      return adapter.findAll(User, {
+        where: {
+          roles: {
+            'contains': 'admin'
+          }
+        }
+      });
+    }).then(function (users) {
+      assert.equal(users.length, 1);
+      assert.deepEqual(users[0], { id: id, name: 'John', roles: [ 'admin' ] });
+      return adapter.destroy(User, id);
+    }).then(function (destroyedUser) {
+      assert.isFalse(!!destroyedUser);
+    });
+  });
+  it('should filter users using the "like" operator', function () {
+    var id;
+
+    return adapter.findAll(User, {
+      where: {
+        name: {
+          'like': 'J'
+        }
+      }
+    }).then(function (users) {
+      assert.equal(users.length, 0);
+      return adapter.create(User, { name: 'John' });
+    }).then(function (user) {
+      id = user.id;
+      return adapter.findAll(User, {
+        where: {
+          name: {
+            'like': 'J'
+          }
+        }
+      });
+    }).then(function (users) {
+      assert.equal(users.length, 1);
+      assert.deepEqual(users[0], { id: id, name: 'John' });
+      return adapter.destroy(User, id);
+    }).then(function (destroyedUser) {
+      assert.isFalse(!!destroyedUser);
+    });
+  });
+  it('should filter users using the "notLike" operator', function () {
+    var id;
+
+    return adapter.findAll(User, {
+      where: {
+        name: {
+          'notLike': 'x'
+        }
+      }
+    }).then(function (users) {
+      assert.equal(users.length, 0);
+      return adapter.create(User, { name: 'John' });
+    }).then(function (user) {
+      id = user.id;
+      return adapter.findAll(User, {
+        where: {
+          name: {
+            'notLike': 'x'
+          }
+        }
+      });
+    }).then(function (users) {
+      assert.equal(users.length, 1);
+      assert.deepEqual(users[0], { id: id, name: 'John' });
+      return adapter.destroy(User, id);
+    }).then(function (destroyedUser) {
+      assert.isFalse(!!destroyedUser);
+    });
+  });
 });


### PR DESCRIPTION
Hi. After further investigation, I've added support for contains/notContains matching against an array field, and like/notLike matching against a string field. The like/notLike operators bring parity with the js-data-sql adapter.

Unfortunately, I don't believe it's possible to use a single operator to handle both cases - against a string field or an array field. Using two operators is necessary, since there's no way from the adapter to determine which type the field has.

Thanks.